### PR TITLE
Puma config tweaks + Rakefile bugfix for staging/production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,13 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.fail_on_error = true
-end
+if %w(development test).member?(ENV.fetch('RAILS_ENV', 'development'))
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.fail_on_error = true
+  end
 
-# In Travis, Rake::Task['spec'] runs by default, just add Rubocop
-# though this is not as helpful for local dev
-task default: [:rubocop]
+  # In Travis, Rake::Task['spec'] runs by default, just add Rubocop
+  # though this is not as helpful for local dev
+  task default: [:rubocop]
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,44 +6,32 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
+rails_env = ENV.fetch('RAILS_ENV') { 'development' }
 max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
+app_dir = File.expand_path('..', __dir__)
+
 threads min_threads_count, max_threads_count
+workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
-bind ENV.fetch('ARK_MANAGER_BIND') { 'tcp://127.0.0.1' }
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-#
-port ENV.fetch('PORT') { 3000 }
+worker_timeout 3600 if rails_env == 'development'
 
 # Specifies the `environment` that Puma will run in.
-#
-environment ENV.fetch('RAILS_ENV') { 'development' }
 
-# Specifies the `pidfile` that Puma will use.
-stdout_redirect('/dev/stdout', '/dev/stderr', true)
+environment rails_env
 
-app_dir = File.expand_path('..', __dir__)
-
-pidfile "#{app_dir}/tmp/pids/server.pid"
-state_path "#{app_dir}/tmp/pids/server.state"
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-workers ENV.fetch('WEB_CONCURRENCY') { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-preload_app!
-
-# Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
+if %w(staging production).member?(rails_env)
+  bind "unix://#{shared_dir}/sockets/bpldc_auth_puma.sock"
+  stdout_redirect("#{app_dir}/log/puma.stdout.log", "#{app_dir}/log/puma.stderr.log", true)
+  pidfile "#{app_dir}/tmp/pids/bpldc_puma_server.pid"
+  state_path "#{app_dir}/tmp/pids/bpldc_puma_server.state"
+else
+  port 3000
+  stdout_redirect('/dev/stdout', '/dev/stderr', true)
+  pidfile "#{app_dir}/tmp/pids/server.pid"
+  state_path "#{app_dir}/tmp/pids/server.state"
+  plugin :tmp_restart
+end


### PR DESCRIPTION
- Added clause for puma when running in staging/production that binds to socket rather than port
- Made Rakefile safe for production/staging by checking what RAILS_ENV is set to