### PR TITLE
add basic info response (fixes #23)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,14 @@ class ApplicationController < ActionController::API
   include ActionController::ImplicitRender
   include ActionView::Layouts
   include ActionController::Caching
+
+  APP_INFO = {
+    app_name: 'bpldc_authority_api',
+    organization: 'Boston Public Library',
+    version: '1.0',
+  }.freeze
+
+  def app_info
+    render json: Oj.dump(APP_INFO), status: :ok
+  end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ if %w(staging production).member?(rails_env)
   state_path "#{app_dir}/tmp/pids/bpldc_puma_server.state"
 else
   port 3000
-  stdout_redirect('/dev/stdout', '/dev/stderr', true)
+  # stdout_redirect('/dev/stdout', '/dev/stderr', true)
   pidfile "#{app_dir}/tmp/pids/server.pid"
   state_path "#{app_dir}/tmp/pids/server.state"
   plugin :tmp_restart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  root 'application#app_info'
+
   mount Qa::Engine => '/qa'
 
   namespace :bpldc, defaults: { format: 'json' } do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe ApplicationController do
+  render_views
+
+  describe 'GET app_info' do
+    it 'renders the app_info response' do
+      get :app_info
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body).length).to be > 1
+      expect(response.content_type).to eq('application/json; charset=utf-8')
+    end
+  end
+end

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Routes' do
+  describe 'app_info' do
+    it 'routes the root url to application#app_info' do
+      expect(get: '/').to route_to(controller: 'application', action: 'app_info')
+    end
+  end
+
   describe 'bpldc routes' do
     describe 'authorities' do
       it 'routes the authorities url to authorities#index' do


### PR DESCRIPTION
Adds a default JSON response to root route (`/`) with some basic application info.