### PR TITLE
Capistrano

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Newton North Public Library',
+    organization: 'Lawrence Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Newton North Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Lowell Public Library',
+    organization: 'Boston Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'North Lawrence Public Library',
+    organization: 'Lowell Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Williamstown Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Lawrence Public Library',
+    organization: 'North Lawrence Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Williamstown Public Library',
+    organization: 'Boston Public Library',
     version: '1.0',
   }.freeze
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -53,10 +53,10 @@ namespace :boston_library do
     end
   end
 
-  desc 'bpldc_authority_api restart bpldc_puma service'
-  task :restart_bpldc_puma do
+  desc "#{fetch(:application)} restart #{fetch(:application)}_puma service"
+  task :"restart_#{fetch(:application)}_puma" do
     on roles(:app), in: :sequence, wait: 5 do
-      execute 'sudo /bin/systemctl restart bpldc_puma.service'
+      execute "sudo /bin/systemctl restart #{fetch(:application)}_puma.service"
       sleep(5)
     end
   end
@@ -72,5 +72,5 @@ end
 before :'rvm:check', :'boston_library:rvm_install_ruby'
 after :'boston_library:gem_update', :'boston_library:install_bundler'
 before :'bundler:install', :'boston_library:gem_update'
-after :'deploy:cleanup', :'boston_library:restart_bpldc_puma'
-after :'boston_library:restart_bpldc_puma', :'boston_library:restart_nginx'
+after :'deploy:cleanup', :"boston_library:restart_#{fetch(:application)}_puma"
+after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -56,7 +56,7 @@ namespace :boston_library do
   desc "#{fetch(:application)} restart #{fetch(:application)}_puma service"
   task :"restart_#{fetch(:application)}_puma" do
     on roles(:app), in: :sequence, wait: 5 do
-      execute "sudo /bin/systemctl restart #{fetch(:application)}_puma.service"
+      execute "sudo /bin/systemctl restart #{fetch(:application)}_puma.socket #{fetch(:application)}_puma.service"
       sleep(5)
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :pty, true
 ## config/deploy/staging.rb cannot be removed from <project>/shared/ directory, because it is temporarily not forcibly using ssl.
 ## Otherwise "curl server_IP" returns 301....
 append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb'
-append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'bundle'
+append :linked_dirs, 'log', 'tmp/pids', 'tmp/sockets', 'bundle'
 
 # Default value for keep_releases is 5
 set :keep_releases, 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :use_sudo, false
 
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
-set :user, Rails.application.credentials.dig(:deploy_staging, :user)
+set :user, Rails.application.credentials.dig(:deploy_testing, :user)
 ## Make user home path dynamic.
 set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :pty, true
 ## config/deploy/staging.rb cannot be removed from <project>/shared/ directory, because it is temporarily not forcibly using ssl.
 ## Otherwise "curl server_IP" returns 301....
 append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb'
-append :linked_dirs, 'log', 'tmp/pids', 'tmp/sockets', 'bundle'
+append :linked_dirs, 'log', 'tmp/cache', 'tmp/pids', 'tmp/sockets', 'bundle'
 
 # Default value for keep_releases is 5
 set :keep_releases, 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,6 @@ set :use_sudo, false
 set :stage_case, 'testing'
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
-# set :user, Rails.application.credentials.dig(:deploy_testing, :user)
 set :user, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :user)
 ## Make user home path dynamic.
 set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,9 +6,11 @@ require File.expand_path('./environment', __dir__)
 
 set :use_sudo, false
 
+set :stage_case, 'testing'
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
-set :user, Rails.application.credentials.dig(:deploy_testing, :user)
+# set :user, Rails.application.credentials.dig(:deploy_testing, :user)
+set :user, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :user)
 ## Make user home path dynamic.
 set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,8 @@ require File.expand_path('./environment', __dir__)
 
 set :use_sudo, false
 
+# If staging_case is set to "testing", capistrano deploys app to testing server.
+# switch :stage_case to "staging" when moving to staging enviroment
 set :stage_case, 'testing'
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,8 @@ set :use_sudo, false
 
 # If staging_case is set to "testing", capistrano deploys app to testing server.
 # switch :stage_case to "staging" when moving to staging enviroment
-set :stage_case, 'testing'
+set :stage_case, 'staging'
+# set :stage_case, 'testing'
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
 set :user, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :user)

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,8 +3,8 @@
 # server-based syntax
 # ======================
 
-set :server_ip, Rails.application.credentials.dig(:deploy_staging, :server)
-set :ssh_key, Rails.application.credentials.dig(:deploy_staging, :ssh_key)
+set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
+set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
 
 set :branch, 'master'
 # set :branch, 'capistrano'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,8 +7,8 @@
 set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
 set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
 
-set :branch, 'master'
-# set :branch, 'capistrano'
+# set :branch, 'master'
+set :branch, 'capistrano'
 
 # role-based syntax
 # ==================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,7 +7,7 @@ set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
 set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
 
 # set :branch, 'master'
-et :branch, 'capistrano'
+set :branch, 'capistrano'
 
 # role-based syntax
 # ==================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -6,8 +6,8 @@
 set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
 set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
 
-set :branch, 'master'
-# set :branch, 'capistrano'
+# set :branch, 'master'
+et :branch, 'capistrano'
 
 # role-based syntax
 # ==================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,9 +3,8 @@
 # server-based syntax
 # ======================
 
-# set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
+# stage_case means different deployment environment: staging, testing...
 set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
-# set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
 set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
 
 # set :branch, 'master'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,8 +3,10 @@
 # server-based syntax
 # ======================
 
-set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
-set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
+# set :server_ip, Rails.application.credentials.dig(:deploy_testing, :server)
+set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
+# set :ssh_key, Rails.application.credentials.dig(:deploy_testing, :ssh_key)
+set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
 
 # set :branch, 'master'
 set :branch, 'capistrano'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,8 +7,8 @@
 set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
 set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
 
-# set :branch, 'master'
-set :branch, 'capistrano'
+set :branch, 'master'
+# set :branch, 'capistrano'
 
 # role-based syntax
 # ==================

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,9 +36,7 @@ end
 if %w(staging production).member?(rails_env)
   bind "unix://#{app_dir}/tmp/sockets/bpldc_authority_api_puma.sock"
   stdout_redirect("#{app_dir}/log/puma.stdout.log", "#{app_dir}/log/puma.stderr.log", true)
-  # pidfile "#{app_dir}/tmp/pids/bpldc_puma_server.pid"
   pidfile "#{app_dir}/tmp/pids/bpldc_authority_api_puma_server.pid"
-  # state_path "#{app_dir}/tmp/pids/bpldc_puma_server.state"
   state_path "#{app_dir}/tmp/pids/bpldc_authority_api_puma_server.state"
 else
   port ENV.fetch('PORT') { 3000 }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,10 +34,12 @@ on_worker_boot do
 end
 
 if %w(staging production).member?(rails_env)
-  bind "unix://#{app_dir}/tmp/sockets/bpldc_auth_puma.sock"
+  bind "unix://#{app_dir}/tmp/sockets/bpldc_authority_api_puma.sock"
   stdout_redirect("#{app_dir}/log/puma.stdout.log", "#{app_dir}/log/puma.stderr.log", true)
-  pidfile "#{app_dir}/tmp/pids/bpldc_puma_server.pid"
-  state_path "#{app_dir}/tmp/pids/bpldc_puma_server.state"
+  # pidfile "#{app_dir}/tmp/pids/bpldc_puma_server.pid"
+  pidfile "#{app_dir}/tmp/pids/bpldc_authority_api_puma_server.pid"
+  # state_path "#{app_dir}/tmp/pids/bpldc_puma_server.state"
+  state_path "#{app_dir}/tmp/pids/bpldc_authority_api_puma_server.state"
 else
   port ENV.fetch('PORT') { 3000 }
   stdout_redirect('/dev/stdout', '/dev/stderr')


### PR DESCRIPTION
Add two features for Capistrano deployment: 
 

>         1, same capistrano script can be used to deploy both "ark-manager" and "bpldc_authority_api"
>        2, a new parameter is set for different deployment servers, like testing server, staging server.

