### PR TITLE
Capistrano

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Ohio Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Florida Public Library',
+    organization: 'Texas Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'New York Public Library',
+    organization: 'Florida Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Texas Public Library',
+    organization: 'Boston Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Texas Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Worcester Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Worcester Public Library',
+    organization: 'Boston Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Boston Public Library',
+    organization: 'Connectict Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Michigan Public Library',
+    organization: 'Utah Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Utah Public Library',
+    organization: 'West Virginia Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Connectict Public Library',
+    organization: 'New York Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'Texas Public Library',
+    organization: 'Michigan Public Library',
     version: '1.0',
   }.freeze
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
 
   APP_INFO = {
     app_name: 'bpldc_authority_api',
-    organization: 'West Virginia Public Library',
+    organization: 'Boston Public Library',
     version: '1.0',
   }.freeze
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :pty, true
 ## When running tasks against staging server, some tasks defined in it needs to be available.
 ## config/deploy/staging.rb cannot be removed from <project>/shared/ directory, because it is temporarily not forcibly using ssl.
 ## Otherwise "curl server_IP" returns 301....
-append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb', 'config/credentials/production.key', 
+append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb', 'config/credentials/production.key' 
 append :linked_dirs, 'log', 'tmp/cache', 'tmp/pids', 'tmp/sockets', 'bundle'
 
 # Default value for keep_releases is 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ lock '~> 3.17.1'
 
 set :use_sudo, false
 
-# If staging_case is set to "testing", capistrano deploys app to testing server.
+## STAGE_NAME is a paramter from Jenkins job: "staging", "qc", and "testing"
 set :stage_case, ENV['STAGE_NAME']
 set :user, ENV['DEPLOY_USER']
 
@@ -24,7 +24,7 @@ set :pty, true
 ## When running tasks against staging server, some tasks defined in it needs to be available.
 ## config/deploy/staging.rb cannot be removed from <project>/shared/ directory, because it is temporarily not forcibly using ssl.
 ## Otherwise "curl server_IP" returns 301....
-append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb'
+append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb', 'config/credentials/production.key', 
 append :linked_dirs, 'log', 'tmp/cache', 'tmp/pids', 'tmp/sockets', 'bundle'
 
 # Default value for keep_releases is 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,7 +12,7 @@ set :user, ENV['DEPLOY_USER']
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
 ## Make user home path dynamic.
-set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"
+set :deploy_to, "/home/#{fetch(:user)}/railsApps/#{fetch(:application)}"
 
 set :rvm_installed, "/home/#{fetch(:user)}/.rvm/bin/rvm"
 set :rvm_ruby_version, File.read(File.expand_path('./../.ruby-version', __dir__)).strip

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :pty, true
 ## When running tasks against staging server, some tasks defined in it needs to be available.
 ## config/deploy/staging.rb cannot be removed from <project>/shared/ directory, because it is temporarily not forcibly using ssl.
 ## Otherwise "curl server_IP" returns 301....
-append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb', 'config/credentials/production.key' 
+append :linked_files, 'config/database.yml', 'config/credentials/staging.key', 'config/environments/staging.rb', 'config/credentials/production.key'
 append :linked_dirs, 'log', 'tmp/cache', 'tmp/pids', 'tmp/sockets', 'bundle'
 
 # Default value for keep_releases is 5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,17 +2,15 @@
 
 # config valid for current version and patch releases of Capistrano
 lock '~> 3.17.1'
-require File.expand_path('./environment', __dir__)
 
 set :use_sudo, false
 
 # If staging_case is set to "testing", capistrano deploys app to testing server.
-# switch :stage_case to "staging" when moving to staging enviroment
-set :stage_case, 'staging'
-# set :stage_case, 'testing'
+set :stage_case, ENV['STAGE_NAME']
+set :user, ENV['DEPLOY_USER']
+
 set :application, 'bpldc_authority_api'
 set :repo_url, "https://github.com/boston-library/#{fetch(:application)}.git"
-set :user, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :user)
 ## Make user home path dynamic.
 set :deploy_to, "/home/#{fetch(:user)}/#{fetch(:application)}"
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -69,6 +69,13 @@ namespace :boston_library do
       execute 'sudo /bin/systemctl reload nginx.service'
     end
   end
+
+  desc 'List current releases'
+  task :list_releases do
+    on roles(:app) do
+      execute "ls -alt #{fetch(:deploy_to)}/releases"
+    end
+  end
 end
 
 after :'bundler:config', :'boston_library:gem_update'
@@ -76,3 +83,4 @@ after :'boston_library:gem_update', :'boston_library:rvm_install_ruby'
 after :'boston_library:rvm_install_ruby', :'boston_library:install_bundler'
 after :'deploy:cleanup', :"boston_library:restart_#{fetch(:application)}_puma"
 after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'
+after :'boston_library:restart_nginx', :'boston_library:list_releases'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,6 +5,7 @@
 
 set :server_ip, ENV['SERVER_IP']
 set :ssh_key, ENV['SSH_KEY']
+
 set :branch, ENV['BRANCH_NAME']
 
 # role-based syntax

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,13 +3,6 @@
 # server-based syntax
 # ======================
 
-# # stage_case means different deployment environment: staging, testing...
-# set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
-# set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
-
-# set :branch, 'master'
-# # set :branch, 'capistrano'
-
 set :server_ip, ENV['SERVER_IP']
 set :ssh_key, ENV['SSH_KEY']
 set :branch, ENV['BRANCH_NAME']

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,12 +3,16 @@
 # server-based syntax
 # ======================
 
-# stage_case means different deployment environment: staging, testing...
-set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
-set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
+# # stage_case means different deployment environment: staging, testing...
+# set :server_ip, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :server)
+# set :ssh_key, Rails.application.credentials.dig("deploy_#{fetch(:stage_case)}".to_sym, :ssh_key)
 
-set :branch, 'master'
-# set :branch, 'capistrano'
+# set :branch, 'master'
+# # set :branch, 'capistrano'
+
+set :server_ip, ENV['SERVER_IP']
+set :ssh_key, ENV['SSH_KEY']
+set :branch, ENV['BRANCH_NAME']
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
This pull request includes: 
- parameterizing :user, :server_ip, ssh_key, and branch, 
- a new task `list_releases` which shows all available release that can be rolled back.  So we don't have to SSH to server to grab the release number. It's purely for more convenience.  
- unify all bpl apps deploying to /home/deployer/railsApps/ directory
- config/deploy/production.rb, in case of deploying to `production` environment